### PR TITLE
Add path properties for Department

### DIFF
--- a/cpe_help/department.py
+++ b/cpe_help/department.py
@@ -24,16 +24,32 @@ class Department(object):
     """
 
     @property
-    def dir(self):
-        """
-        Return the directory containing the department data
-
-        Returns
-        -------
-        Path
-            A pathlib.Path object representing the directory.
-        """
+    def path(self):
         return DATA_DIR / 'departments' / self.name
+
+    @property
+    def external_path(self):
+        return self.path / 'external'
+
+    @property
+    def raw_path(self):
+        return self.path / 'raw'
+
+    @property
+    def preprocessed_path(self):
+        return self.path / 'preprocessed'
+
+    @property
+    def external_acs_path(self):
+        return self.external_path / 'ACS'
+
+    @property
+    def external_shapefile_path(self):
+        return self.external_path / 'police_districts'
+
+    @property
+    def preprocessed_shapefile_path(self):
+        return self.preprocessed_path / 'police_districts'
 
     def __new__(cls, name):
         """

--- a/cpe_help/department.py
+++ b/cpe_help/department.py
@@ -112,14 +112,17 @@ class Department(object):
         Source: './external/shapefiles'
         Destination: './preprocessed/shapefiles'
         """
-        raw = gpd.read_file(str(self.dir / 'external' / 'shapefiles'))
+        src = str(self.external_shapefile_path)
+        dst = str(self.preprocessed_shapefile_path)
+
+        raw = gpd.read_file(src)
 
         if not raw.crs:
             raise InputError(f"Department {self.name} has no projection defined")
         pre = raw.to_crs(crs.epsg4326)
 
-        ensure_path(self.dir / 'preprocessed' / 'shapefiles')
-        pre.to_file(str(self.dir / 'preprocessed' / 'shapefiles'))
+        ensure_path(dst)
+        pre.to_file(dst)
 
 
 def list_departments():

--- a/cpe_help/departments/dept3700027.py
+++ b/cpe_help/departments/dept3700027.py
@@ -14,10 +14,13 @@ from cpe_help.util.path import ensure_path
 
 class Department3700027(Department):
     def preprocess_shapefile(self):
-        raw = gpd.read_file(str(self.dir / 'external' / 'shapefiles'))
+        src = str(self.external_shapefile_path)
+        dst = str(self.preprocessed_shapefile_path)
+
+        raw = gpd.read_file(src)
         raw.crs = crs.esri102739
 
         pre = raw.to_crs(crs.epsg4326)
 
-        ensure_path(self.dir / 'preprocessed' / 'shapefiles')
-        pre.to_file(str(self.dir / 'preprocessed' / 'shapefiles'))
+        ensure_path(dst)
+        pre.to_file(dst)

--- a/dodo.py
+++ b/dodo.py
@@ -232,8 +232,7 @@ def task_preprocess_shapefiles():
         yield {
             'name': dept.name,
             'file_dep': [x for x in src.iterdir()],
-            'targets': [dst / f"shapefiles.{ext}" for ext in extensions] +
-                       [dst],
+            'targets': [dst],
             'actions': [dept.preprocess_shapefile],
             'clean': True,
         }

--- a/dodo.py
+++ b/dodo.py
@@ -154,7 +154,7 @@ def task_spread_acs_tables():
         #       and StopIteraction exception in a weird place and
         #       complicate debugging
         src_dir = dept_dir / f"{name}_ACS_data"
-        dst_dir = dept.dir / 'external' / 'ACS'
+        dst_dir = dept.external_acs_path
         src_files = [list(x.glob('*_with_ann.csv'))[0]
                      for x in src_dir.iterdir()
                      if x.is_dir()]
@@ -184,7 +184,7 @@ def task_spread_shapefiles():
         name = dept_dir.name[5:]
         dept = Department(name)
         src_dir = dept_dir / f"{name}_Shapefiles"
-        dst_dir = dept.dir / 'external' / 'shapefiles'
+        dst_dir = dept.external_shapefile_path
         src_files = list(src_dir.iterdir())
         dst_files = [dst_dir / x.name for x in src_files]
 
@@ -210,7 +210,7 @@ def task_spread_other():
         name = dept_dir.name[5:]
         dept = Department(name)
         src_files = [x for x in dept_dir.iterdir() if x.is_file()]
-        dst_files = [dept.dir / 'external' / x.name for x in src_files]
+        dst_files = [dept.external_path / x.name for x in src_files]
 
         yield {
             'name': name,
@@ -227,8 +227,8 @@ def task_preprocess_shapefiles():
     extensions = ['cpg', 'dbf', 'prj', 'shp', 'shx']
 
     for dept in list_departments():
-        src = dept.dir / 'external' / 'shapefiles'
-        dst = dept.dir / 'preprocessed' / 'shapefiles'
+        src = dept.external_shapefile_path
+        dst = dept.preprocessed_shapefile_path
         yield {
             'name': dept.name,
             'file_dep': [x for x in src.iterdir()],
@@ -274,12 +274,12 @@ def task_download_extra():
     # just a prototype for other data that may be retrieved
     yield downloader(
         'https://data.austintexas.gov/api/views/u2k2-n8ez/rows.csv?accessType=DOWNLOAD',
-        Department('37-00027').dir / 'raw' / 'OIS.csv',
+        Department('37-00027').raw_path / 'OIS.csv',
         name='austin_ois',
     )
 
     yield downloader(
         'https://data.austintexas.gov/api/views/g3bw-w7hh/rows.csv?accessType=DOWNLOAD',
-        Department('37-00027').dir / 'raw' / 'crime_reports.csv',
+        Department('37-00027').raw_path / 'crime_reports.csv',
         name='austin_crimes',
     )

--- a/notebooks/playground/02-department-states.ipynb
+++ b/notebooks/playground/02-department-states.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = gpd.read_file(str(Department('11-00091').dir / 'external' / 'shapefiles'))"
+    "df = gpd.read_file(str(Department('11-00091').external_shapefile_path))"
    ]
   },
   {


### PR DESCRIPTION
In lots of places in the code, we were using `dept.dir / 'dirA' / 'dirB' / 'filname.ext'`. While this approach is clearly visible in what it is achieving, it lacks consistency. Also, it makes it difficult to change paths later. As, to change the path of one single file, one would have to touch lots of different places of the code.

To solve this, I created custom properties for the Department class. The path properties in the Department class itself are gonna be those that are shared between every department. For single departments (subclasses), there may also be some other path properties, and they may override the original properties too.